### PR TITLE
chore: rename arguments 'async' to 'is_async'

### DIFF
--- a/facebook_business/asyncobjects.py
+++ b/facebook_business/asyncobjects.py
@@ -705,9 +705,9 @@ class AdAccount(AbstractCrudAioObject, adaccount.AdAccount):
     def get_insights_aio(self, fields=None, params=None, limit=1000, is_async=False,
                          has_action=None, needs_action_device=None, has_filters=False, for_date=None):
         """
-        If async is False, returns EdgeIterator.
+        If 'is_async' is False, returns EdgeIterator.
 
-        If async is True, creates a job and job iterator for it and
+        If 'is_async' is True, creates a job and job iterator for it and
         returns the job iterator (AsyncAioJobIterator class, subclass of EdgeIterator).
 
         Regardless the async parameter, it puts the iterator to the queue so that
@@ -748,9 +748,9 @@ class Campaign(AbstractCrudAioObject, baseobjects.Campaign):
     def get_insights_aio(self, fields=None, params=None, limit=1000, is_async=False,
                          has_action=None, needs_action_device=None, for_date=None):
         """
-        If async is False, returns EdgeIterator.
+        If 'is_async' is False, returns EdgeIterator.
 
-        If async is True, creates a job and job iterator for it and
+        If 'is_async' is True, creates a job and job iterator for it and
         returns the job iterator (AsyncAioJobIterator class, subclass of EdgeIterator).
 
         Regardless the async parameter, it puts the iterator to the queue so that
@@ -783,9 +783,9 @@ class AdSet(AbstractCrudAioObject, baseobjects.AdSet):
     def get_insights_aio(self, fields=None, params=None, limit=1000, is_async=False,
                          has_action=None, needs_action_device=None):
         """
-        If async is False, returns EdgeIterator.
+        If 'is_async' is False, returns EdgeIterator.
 
-        If async is True, creates a job and job iterator for it and
+        If 'is_async' is True, creates a job and job iterator for it and
         returns the job iterator (AsyncAioJobIterator class, subclass of EdgeIterator).
 
         Regardless the async parameter, it puts the iterator to the queue so that
@@ -894,9 +894,9 @@ class Ad(AbstractCrudAioObject, ad.Ad):
     def get_insights_aio(self, fields=None, params=None, limit=1000, is_async=False,
                          has_action=None, needs_action_device=None):
         """
-        If async is False, returns EdgeIterator.
+        If 'is_async' is False, returns EdgeIterator.
 
-        If async is True, creates a job and job iterator for it and
+        If 'is_async' is True, creates a job and job iterator for it and
         returns the job iterator (AsyncAioJobIterator class, subclass of EdgeIterator).
 
         Regardless the async parameter, it puts the iterator to the queue so that

--- a/facebook_business/asyncobjects/__init__.py
+++ b/facebook_business/asyncobjects/__init__.py
@@ -146,9 +146,9 @@ class AdAccount(AbstractCrudAioObject, adaccount.AdAccount):
                          has_action=None, needs_action_device=None,
                          has_filters=False, for_date=None, needs_carousel_name=False):
         """
-        If async is False, returns EdgeIterator.
+        If 'is_async' is False, returns EdgeIterator.
 
-        If async is True, creates a job and job iterator for it and
+        If 'is_async' is True, creates a job and job iterator for it and
         returns the job iterator (AsyncAioJobIterator class, subclass of EdgeIterator).
 
         Regardless the async parameter, it puts the iterator to the queue so that
@@ -183,9 +183,9 @@ class Campaign(AbstractCrudAioObject, campaign.Campaign):
                          has_action=None, needs_action_device=None,
                          has_filters=False, for_date=None, needs_carousel_name=False):
         """
-        If async is False, returns EdgeIterator.
+        If 'is_async' is False, returns EdgeIterator.
 
-        If async is True, creates a job and job iterator for it and
+        If 'is_async' is True, creates a job and job iterator for it and
         returns the job iterator (AsyncAioJobIterator class, subclass of EdgeIterator).
 
         Regardless the async parameter, it puts the iterator to the queue so that
@@ -220,9 +220,9 @@ class AdSet(AbstractCrudAioObject, adset.AdSet):
                          has_action=None, needs_action_device=None,
                          has_filters=False, for_date=None, needs_carousel_name=False):
         """
-        If async is False, returns EdgeIterator.
+        If 'is_async' is False, returns EdgeIterator.
 
-        If async is True, creates a job and job iterator for it and
+        If 'is_async' is True, creates a job and job iterator for it and
         returns the job iterator (AsyncAioJobIterator class, subclass of EdgeIterator).
 
         Regardless the async parameter, it puts the iterator to the queue so that
@@ -342,9 +342,9 @@ class Ad(AbstractCrudAioObject, ad.Ad):
                          has_action=None, needs_action_device=None,
                          has_filters=False, for_date=None, needs_carousel_name=False):
         """
-        If async is False, returns EdgeIterator.
+        If 'is_async' is False, returns EdgeIterator.
 
-        If async is True, creates a job and job iterator for it and
+        If 'is_async' is True, creates a job and job iterator for it and
         returns the job iterator (AsyncAioJobIterator class, subclass of EdgeIterator).
 
         Regardless the async parameter, it puts the iterator to the queue so that

--- a/facebook_business/test/async_adaccount_docs.py
+++ b/facebook_business/test/async_adaccount_docs.py
@@ -44,7 +44,7 @@ class AdAccountAsyncDocsTestCase(AsyncDocsTestCase):
         ], params={
             'level': Insights.Level.campaign,
             'date_preset': Insights.Preset.last_week,
-        }, async=True)
+        }, is_async=True)
         while not job:
             time.sleep(0.3)
             job.remote_read()

--- a/facebook_business/test/async_insights_docs.py
+++ b/facebook_business/test/async_insights_docs.py
@@ -28,7 +28,7 @@ class AdAccountAsyncDocsTestCase(AsyncDocsTestCase):
         ], params={
             'level': Insights.Level.campaign,
             'date_preset': Insights.Preset.last_week,
-        }, async=True)
+        }, is_async=True)
         while not job:
             time.sleep(0.3)
             job.remote_read()


### PR DESCRIPTION
Improve python 3.7 compatibility by not using the same symbol name as
the upcoming reserved word `async`.

Fixes notices like this one:

`DeprecationWarning: 'async' and 'await' will become reserved keywords in
Python 3.7`

Unfortunately, this will also require updates to all client code using the library.